### PR TITLE
Fix: Update tailwind.config.js to use ES module syntax

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 import {nextui} from '@nextui-org/theme'
 
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   content: [
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
Hotfix to resolve error caused by loading ES module tailwind.config.js as CommonJS. Updates tailwind.config.js to use ES module syntax to ensure compatibility with Next.js.