### PR TITLE
feat: upgrade nextjs to v16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Next.js & HeroUI Template
 
-This is a template for creating applications using Next.js 15 (app directory) and HeroUI (v3).
+This is a template for creating applications using Next.js 16 (app directory) and HeroUI (v3).
 
 [Try it on CodeSandbox](https://githubbox.com/heroui-inc/heroui/next-app-template)
 
 ## Technologies Used
 
-- [Next.js 15](https://nextjs.org/docs/getting-started)
+- [Next.js 16](https://nextjs.org/docs/getting-started)
 - [HeroUI v3](https://heroui.com/)
 - [Tailwind CSS](https://tailwindcss.com/)
 - [Tailwind Variants](https://tailwind-variants.org)

--- a/components/theme-switch.tsx
+++ b/components/theme-switch.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { FC } from "react";
+import { FC, useEffect, useState } from "react";
 import { useTheme } from "next-themes";
 import clsx from "clsx";
 
@@ -11,6 +9,7 @@ export interface ThemeSwitchProps {
 }
 
 export const ThemeSwitch: FC<ThemeSwitchProps> = ({ className }) => {
+  const [isMounted, setIsMounted] = useState(false);
   const { setTheme, resolvedTheme } = useTheme();
 
   const isLight = resolvedTheme === "light";
@@ -18,6 +17,13 @@ export const ThemeSwitch: FC<ThemeSwitchProps> = ({ className }) => {
   const handleToggle = () => {
     setTheme(isLight ? "dark" : "light");
   };
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+
+  if (!isMounted) return <div aria-hidden className="w-6 h-6" />;
 
   return (
     <button

--- a/package.json
+++ b/package.json
@@ -4,20 +4,20 @@
 	"type": "module",
 	"private": true,
 	"scripts": {
-		"dev": "next dev --turbopack",
+		"dev": "next dev",
 		"build": "next build",
 		"start": "next start",
 		"lint": "eslint --fix"
 	},
 	"dependencies": {
-		"@heroui/react": "3.0.3",
-		"@heroui/styles": "3.0.3",
+		"@heroui/react": "3.0.4",
+		"@heroui/styles": "3.0.4",
 		"clsx": "2.1.1",
 		"intl-messageformat": "10.7.16",
-		"next": "15.5.9",
+		"next": "16.2.6",
 		"next-themes": "0.4.6",
-		"react": "^19.0.0",
-		"react-dom": "^19.0.0"
+		"react": "19.2.6",
+		"react-dom": "19.2.6"
 	},
 	"devDependencies": {
 		"@eslint/compat": "1.2.8",
@@ -25,9 +25,9 @@
 		"@eslint/js": "9.25.1",
 		"@next/eslint-plugin-next": "16.2.0",
 		"@tailwindcss/postcss": "4.1.11",
-		"@types/node": "20.5.7",
-		"@types/react": "^19.0.0",
-		"@types/react-dom": "^19.0.0",
+		"@types/node": "20.9.0",
+		"@types/react": "19.2.14",
+		"@types/react-dom": "19.2.3",
 		"@typescript-eslint/eslint-plugin": "8.34.1",
 		"@typescript-eslint/parser": "8.34.1",
 		"eslint": "9.25.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -12,7 +16,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -20,9 +24,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
This pull request updates the project to use Next.js 16 and includes several dependency upgrades, along with minor improvements to the `ThemeSwitch` component. The most significant changes are the framework and library version updates for better compatibility and stability, as well as a fix for a hydration issue in the theme switcher.

**Framework and Dependency Upgrades:**

* Upgraded `next` from version 15.5.9 to 16.2.6, and updated the documentation and dependencies to reflect the move to Next.js 16. (`README.md`, `package.json`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R9) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7-R30)
* Updated `@heroui/react` and `@heroui/styles` from 3.0.3 to 3.0.4 for the latest features and fixes. (`package.json`)
* Bumped `react` and `react-dom` dependencies from `^19.0.0` to `19.2.6`, and updated related `@types` packages for improved type safety. (`package.json`)

**Component Improvements:**

* Fixed a hydration mismatch issue in `ThemeSwitch` by introducing an `isMounted` state and rendering a placeholder until the component is mounted on the client. (`components/theme-switch.tsx`) [[1]](diffhunk://#diff-11eb051da5208ec66beebba39546567be168c0759491e36d6b0d7e72521c13ddL1-R1) [[2]](diffhunk://#diff-11eb051da5208ec66beebba39546567be168c0759491e36d6b0d7e72521c13ddR12) [[3]](diffhunk://#diff-11eb051da5208ec66beebba39546567be168c0759491e36d6b0d7e72521c13ddR21-R27)

**Build Tooling:**

* Removed the `--turbopack` flag from the `dev` script to use the default Next.js development server. (`package.json`)